### PR TITLE
Sync animations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,4 +143,3 @@ core/build/tmp/compileJava/previous-compilation-data.bin
 core/build/tmp/compileJava/previous-compilation-data.bin
 desktop/build/tmp/compileJava/previous-compilation-data.bin
 .gradle/file-system.probe
-.gradle/file-system.probe

--- a/core/src/edu/cornell/gdiac/rabbeat/ObjectController.java
+++ b/core/src/edu/cornell/gdiac/rabbeat/ObjectController.java
@@ -157,35 +157,36 @@ public class ObjectController {
 
         // Allocating player animations
         //  Synth
+        //Note: For animations, frame durations must be 1 for AnimationSync to work
         synthIdleAtlas = new TextureAtlas(Gdx.files.internal("player/synthIdle.atlas"));
-        synthIdleAnimation = new Animation<TextureRegion>(0.1f, synthIdleAtlas.findRegions("synthIdle"), Animation.PlayMode.LOOP);
+        synthIdleAnimation = new Animation<TextureRegion>(1, synthIdleAtlas.findRegions("synthIdle"), Animation.PlayMode.LOOP);
 
         synthWalkAtlas = new TextureAtlas(Gdx.files.internal("player/synthWalk.atlas"));
-        synthWalkAnimation = new Animation<TextureRegion>(0.06f, synthWalkAtlas.findRegions("synthWalk"), Animation.PlayMode.LOOP);
+        synthWalkAnimation = new Animation<TextureRegion>(1, synthWalkAtlas.findRegions("synthWalk"), Animation.PlayMode.LOOP);
 
         synthJumpAtlas = new TextureAtlas(Gdx.files.internal("player/synthJump.atlas"));
-        synthJumpAnimation = new Animation<TextureRegion>(0.08f, synthJumpAtlas.findRegions("synthJump"), Animation.PlayMode.NORMAL);
+        synthJumpAnimation = new Animation<TextureRegion>(1, synthJumpAtlas.findRegions("synthJump"), Animation.PlayMode.NORMAL);
 
         //  Jazz
         jazzIdleAtlas = new TextureAtlas(Gdx.files.internal("player/jazzIdle.atlas"));
-        jazzIdleAnimation = new Animation<TextureRegion>(0.11f, jazzIdleAtlas.findRegions("jazzIdle"), Animation.PlayMode.LOOP);
+        jazzIdleAnimation = new Animation<TextureRegion>(1, jazzIdleAtlas.findRegions("jazzIdle"), Animation.PlayMode.LOOP);
 
         jazzWalkAtlas = new TextureAtlas(Gdx.files.internal("player/jazzWalk.atlas"));
-        jazzWalkAnimation = new Animation<TextureRegion>(0.08f, jazzWalkAtlas.findRegions("jazzWalk"), Animation.PlayMode.LOOP);
+        jazzWalkAnimation = new Animation<TextureRegion>(1, jazzWalkAtlas.findRegions("jazzWalk"), Animation.PlayMode.LOOP);
 
         jazzJumpAtlas = new TextureAtlas(Gdx.files.internal("player/jazzJump.atlas"));
-        jazzJumpAnimation = new Animation<TextureRegion>(0.08f, jazzJumpAtlas.findRegions("jazzJump"), Animation.PlayMode.NORMAL);
+        jazzJumpAnimation = new Animation<TextureRegion>(1, jazzJumpAtlas.findRegions("jazzJump"), Animation.PlayMode.NORMAL);
 
         //  Allocating enemy animations
         //  Bear
         bearIdleAtlas = new TextureAtlas(Gdx.files.internal("enemies/bearIdle.atlas"));
-        bearIdleAnimation = new Animation<TextureRegion>(0.1f, bearIdleAtlas.findRegions("bearIdle"), Animation.PlayMode.LOOP);
+        bearIdleAnimation = new Animation<TextureRegion>(1, bearIdleAtlas.findRegions("bearIdle"), Animation.PlayMode.LOOP);
         //  Bat
         batIdleAtlas = new TextureAtlas(Gdx.files.internal("enemies/bearIdle.atlas"));
-        batIdleAnimation = new Animation<TextureRegion>(0.1f, bearIdleAtlas.findRegions("bearIdle"), Animation.PlayMode.LOOP);
+        batIdleAnimation = new Animation<TextureRegion>(1, bearIdleAtlas.findRegions("bearIdle"), Animation.PlayMode.LOOP);
         //  Hedgehog
         hedgehogIdleAtlas = new TextureAtlas(Gdx.files.internal("enemies/bearIdle.atlas"));
-        hedgehogIdleAnimation = new Animation<TextureRegion>(0.1f, bearIdleAtlas.findRegions("bearIdle"), Animation.PlayMode.LOOP);
+        hedgehogIdleAnimation = new Animation<TextureRegion>(1, bearIdleAtlas.findRegions("bearIdle"), Animation.PlayMode.LOOP);
 
 
         // Allocate the tiles

--- a/core/src/edu/cornell/gdiac/rabbeat/Player.java
+++ b/core/src/edu/cornell/gdiac/rabbeat/Player.java
@@ -18,6 +18,7 @@ import com.badlogic.gdx.graphics.g2d.Animation;
 
 import com.badlogic.gdx.utils.JsonValue;
 import edu.cornell.gdiac.rabbeat.obstacles.*;
+import edu.cornell.gdiac.rabbeat.sync.ISyncedAnimated;
 
 /**
  * Player avatar for the plaform game.
@@ -25,7 +26,7 @@ import edu.cornell.gdiac.rabbeat.obstacles.*;
  * Note that this class returns to static loading.  That is because there are
  * no other subclasses that we might loop through.
  */
-public class Player extends CapsuleGameObject implements IGenreObject {
+public class Player extends CapsuleGameObject implements ISyncedAnimated, IGenreObject {
 	/** The initializing data (to avoid magic numbers) */
 	private final JsonValue data;
 
@@ -232,13 +233,6 @@ public class Player extends CapsuleGameObject implements IGenreObject {
 	public float playerScale;
 
 	/**
-	 * Sets the player's current animation
-	 */
-	public void setAnimation(Animation<TextureRegion> animation){
-		this.animation = animation;
-	}
-
-	/**
 	 * Returns true if this character is facing right
 	 *
 	 * @return true if this character is facing right
@@ -407,7 +401,6 @@ public class Player extends CapsuleGameObject implements IGenreObject {
 
             animationUpdate();
 
-		stateTime += dt;
 		super.update(dt);
 	}
 
@@ -494,4 +487,14 @@ public class Player extends CapsuleGameObject implements IGenreObject {
 		}
 	}
 
+	public void setAnimation(Animation<TextureRegion> animation){
+		this.animation = animation;
+	}
+
+	public void updateAnimationFrame(){
+		stateTime++;
+	}
+	public float getBeat() {return 1;}
+
+	public void beatAction(){}
 }

--- a/core/src/edu/cornell/gdiac/rabbeat/obstacles/enemies/BatEnemy.java
+++ b/core/src/edu/cornell/gdiac/rabbeat/obstacles/enemies/BatEnemy.java
@@ -29,9 +29,6 @@ import edu.cornell.gdiac.rabbeat.sync.ISynced;
 public class BatEnemy extends Enemy implements ISynced, IGenreObject {
     private ShapeRenderer shapeRenderer = new ShapeRenderer();
 
-    /** Current genre that the game is on */
-    public Genre curGenre = Genre.SYNTH;
-
     /** the radius of attack of the bat's echo */
     private float echoRadius;
 

--- a/core/src/edu/cornell/gdiac/rabbeat/obstacles/enemies/BearEnemy.java
+++ b/core/src/edu/cornell/gdiac/rabbeat/obstacles/enemies/BearEnemy.java
@@ -17,7 +17,7 @@ import com.badlogic.gdx.graphics.g2d.Animation;
  * Bear enemy avatar for the platform game.
  * Bears shoot bullets that are synced to the beat.
  */
-public class BearEnemy extends Enemy implements ISynced, IGenreObject {
+public class BearEnemy extends Enemy implements IGenreObject {
 
     private float synthBeat = 1;
     private float jazzBeat = .5f;
@@ -31,9 +31,6 @@ public class BearEnemy extends Enemy implements ISynced, IGenreObject {
 
     /** Number of beats the bullet exists in jazz */
     private int jazzBulletTime = 8;
-
-    /** Current genre that the game is on */
-    public Genre curGenre = Genre.SYNTH;
 
     /** Scale of the world */
     private Vector2 scale = GameController.getInstance().getScale();

--- a/core/src/edu/cornell/gdiac/rabbeat/obstacles/enemies/BeeHive.java
+++ b/core/src/edu/cornell/gdiac/rabbeat/obstacles/enemies/BeeHive.java
@@ -12,8 +12,6 @@ import edu.cornell.gdiac.rabbeat.sync.ISynced;
 
 public class BeeHive extends Enemy implements ISynced, IGenreObject {
 
-    public Genre curGenre = Genre.SYNTH;
-
     public ObjectController objectController;
 
     ObjectController oc = GameController.getInstance().objectController;

--- a/core/src/edu/cornell/gdiac/rabbeat/obstacles/enemies/Enemy.java
+++ b/core/src/edu/cornell/gdiac/rabbeat/obstacles/enemies/Enemy.java
@@ -12,17 +12,21 @@ import com.badlogic.gdx.physics.box2d.*;
 //package edu.cornell.gdiac.physics.platform;
 
 import com.badlogic.gdx.utils.JsonValue;
+import edu.cornell.gdiac.rabbeat.sync.ISyncedAnimated;
 
 /**
  * Enemy parent class for the platform game.
  */
-public abstract class Enemy extends CapsuleGameObject {
+public abstract class Enemy extends CapsuleGameObject implements ISyncedAnimated {
 
     /** Enum containing the state of the enemy */
     protected enum EnemyState{
         IDLE,
         ATTACKING
     }
+
+    /** Current genre that the game is on */
+    public Genre curGenre = Genre.SYNTH;
 
     /** The scale of the enemy */
     private float enemyScale;
@@ -41,6 +45,7 @@ public abstract class Enemy extends CapsuleGameObject {
 
     /** The elapsed time for animationUpdate */
     private float stateTime = 0;
+
 
     //range: how far away player is --> beat action called whenever an action is supposed to hapepn on beat
     //create switch states (wandering, shooting, etc). ENUM
@@ -142,13 +147,6 @@ public abstract class Enemy extends CapsuleGameObject {
     /** Switches enemy attacking state depending on its current state */
     public abstract void switchState();
 
-    /**
-     * Sets the enemy's current animation
-     */
-    public void setAnimation(Animation<TextureRegion> animation){
-        this.animation = animation;
-    }
-
 
     /** Returns the x position of the player */
     public float playerXPosition(){
@@ -183,5 +181,16 @@ public abstract class Enemy extends CapsuleGameObject {
     public void setType (String type) {
         this.type = type;
     }
+
+    public void setAnimation(Animation<TextureRegion> animation){
+        this.animation = animation;
+    }
+
+    public void updateAnimationFrame(){
+        stateTime++;
+    }
+    public float getBeat() {return 1;}
+
+    public void beatAction(){}
 
 }

--- a/core/src/edu/cornell/gdiac/rabbeat/obstacles/enemies/HedgehogEnemy.java
+++ b/core/src/edu/cornell/gdiac/rabbeat/obstacles/enemies/HedgehogEnemy.java
@@ -16,9 +16,6 @@ public class HedgehogEnemy extends Enemy implements ISynced, IGenreObject {
     /** The distance that the hedgehog rolls */
     private final float rollingDistance;
 
-    /** Current genre that the game is on */
-    public Genre curGenre = Genre.SYNTH;
-
     /** The endpoint equivalent to the hedgehog's starting position */
     private final float point1 = getX();
 

--- a/core/src/edu/cornell/gdiac/rabbeat/sync/AnimationSync.java
+++ b/core/src/edu/cornell/gdiac/rabbeat/sync/AnimationSync.java
@@ -11,7 +11,7 @@ public class AnimationSync implements ISynced{
     /** The animated objects that need to be synced with the game*/
     public Array<ISyncedAnimated> animatedObjects = new Array<>();
     /** Number of frames that play per beat */
-    float ANIMATION_FPB = 2.0f;
+    float ANIMATION_FPB = 4.0f;
 
     @Override
     public float getBeat() {

--- a/core/src/edu/cornell/gdiac/rabbeat/sync/AnimationSync.java
+++ b/core/src/edu/cornell/gdiac/rabbeat/sync/AnimationSync.java
@@ -1,0 +1,27 @@
+package edu.cornell.gdiac.rabbeat.sync;
+
+import com.badlogic.gdx.utils.Array;
+
+public class AnimationSync implements ISynced{
+    /**
+     * The purpose of this class is to sync all animations to the beat. When beatAction is called,
+     * all the animations will update to the next animation frame.
+     */
+
+    /** The animated objects that need to be synced with the game*/
+    public Array<ISyncedAnimated> animatedObjects = new Array<>();
+    /** Number of frames that play per beat */
+    float ANIMATION_FPB = 2.0f;
+
+    @Override
+    public float getBeat() {
+        return ANIMATION_FPB;
+    }
+
+    @Override
+    public void beatAction() {
+        for(ISyncedAnimated a : animatedObjects){
+            a.updateAnimationFrame();
+        }
+    }
+}

--- a/core/src/edu/cornell/gdiac/rabbeat/sync/ISyncedAnimated.java
+++ b/core/src/edu/cornell/gdiac/rabbeat/sync/ISyncedAnimated.java
@@ -1,0 +1,18 @@
+package edu.cornell.gdiac.rabbeat.sync;
+
+import com.badlogic.gdx.graphics.g2d.Animation;
+import com.badlogic.gdx.graphics.g2d.TextureRegion;
+
+public interface ISyncedAnimated extends ISynced{
+    /**
+     * Sets the animation of the synced animated object.
+     * NOTE: The animation state must have frame durations of 1 in order for this implementation to work
+     */
+    public void setAnimation(Animation<TextureRegion> animation);
+
+    /**
+     * Called in updateBeat from {@code SyncController} to update the current frame that should be
+     * played in the animation
+     */
+    public void updateAnimationFrame();
+}

--- a/core/src/edu/cornell/gdiac/rabbeat/sync/SyncController.java
+++ b/core/src/edu/cornell/gdiac/rabbeat/sync/SyncController.java
@@ -14,12 +14,16 @@ public class SyncController {
 
     /**The audio delay of the audio  in seconds*/
     private float delay = 0;
+    /** The intervals of each of the synced objects in the game */
     private Array<Interval> intervals = new Array<>();
+    /** The interval that represents the animation update */
+    private AnimationSync animationSync = new AnimationSync();
 
     /** TODO: Create description and use SoundController instead.  Maybe even delete this function*/
     public void setSync(Music _synth, Music _jazz){
         synth = _synth;
         jazz = _jazz;
+        addSync(animationSync);
     }
 
     /**Adds _delay to the delay field
@@ -52,11 +56,15 @@ public class SyncController {
 
     /**
      * Creates an {@link Interval} object from {@param syncedObject} and adds it to the intervals
-     * in order to be synced
+     * in order to be synced. If the synced object is animated, add to the list of animated synced objects
      * @param syncedObject A synced object
      */
     public void addSync(ISynced syncedObject){
             Interval interval = new Interval(syncedObject);
             intervals.add(interval);
+            if(syncedObject instanceof ISyncedAnimated){
+                System.out.println("Animated object");;
+                animationSync.animatedObjects.add((ISyncedAnimated)(syncedObject));
+            }
         }
     }


### PR DESCRIPTION
- Create AnimationSync which will control when animations are updated
- All animations MUST have an frameduration of 1
- moved curGenre into Enemy

Issues with Implementation for future planning
- Player must have getBeat and beatAction despite not having any real actions that care about those functions.
Possible Solution: Have the player's genre switch ability on cooldown with the beat
- For updateAnimationFrame, there is only one way of implementing this and stateTime must exist in order for this to work. However, java does not allow multiple inheritences but interfaces does not allow for explicit function implementations
Possible Solution: Ignore this? This may not be a huge problem and creating new classes such a AnimatedObject is probably overly complicated to a simple problem.